### PR TITLE
Add check for add_action

### DIFF
--- a/load.php
+++ b/load.php
@@ -4,6 +4,11 @@ namespace HM\Platform\Multilingual;
 
 use HM\Platform;
 
+// Don't self-initialize if this is not a Platform execution.
+if ( ! function_exists( 'add_action' ) ) {
+	return;
+}
+
 add_action( 'hm-platform.modules.init', function () {
 	Platform\register_module( 'multilingual', __DIR__, 'Multilingual', [] );
 } );


### PR DESCRIPTION
Per https://github.com/humanmade/platform-dev/issues/323, we are screwing up any inclusion of autoload.php outside of the wp-config.php. We are discussing a better long term solution in https://github.com/humanmade/platform-dev/pull/325, but this is intended to get things functioning.